### PR TITLE
Fix: target line is not changed

### DIFF
--- a/lua/substitute/utils.lua
+++ b/lua/substitute/utils.lua
@@ -165,13 +165,13 @@ function utils.compare_regions(origin, target)
   end
 
   local origin_offset = {
-    start = vim.api.nvim_buf_get_offset(0, origin.marks.start.row) + origin.marks.start.col,
-    finish = vim.api.nvim_buf_get_offset(0, origin.marks.finish.row) + origin.marks.finish.col,
+    start = vim.api.nvim_buf_get_offset(0, origin.marks.start.row - 1) + origin.marks.start.col,
+    finish = vim.api.nvim_buf_get_offset(0, origin.marks.finish.row - 1) + origin.marks.finish.col,
   }
 
   local target_offset = {
-    start = vim.api.nvim_buf_get_offset(0, target.marks.start.row) + target.marks.start.col,
-    finish = vim.api.nvim_buf_get_offset(0, target.marks.finish.row) + target.marks.finish.col,
+    start = vim.api.nvim_buf_get_offset(0, target.marks.start.row - 1) + target.marks.start.col,
+    finish = vim.api.nvim_buf_get_offset(0, target.marks.finish.row - 1) + target.marks.finish.col,
   }
 
   --  < if origin comes before target


### PR DESCRIPTION
Lines aren't swapped if the origin line is longer than the target.  The
origin line is replaced by the target line, but the target line remains
unchanged.  The cause is passing 1-indexed number of line
`nvim_buf_get_offset`,  but the function accepts a 0-indexed line
number.

Consider the following example
```
very long and descriptive line
short line
```

Pick the long line and swap it with the short one. You'll get

```
short line
short line
```