### PR TITLE
feat: allow specifying the text for motion1 and allow specifying range for motion2

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ This will use this motion for the first motion of range substitution.
 eg. `lua require('substitute.range').operator({ motion1 = 'iW' })` will select
 inner WORD as subject of substitution.
 
-### `range.subject`
+#### `range.subject`
 
 Default : `nil`
 

--- a/README.md
+++ b/README.md
@@ -262,6 +262,22 @@ This will use this motion for the first motion of range substitution.
 eg. `lua require('substitute.range').operator({ motion1 = 'iW' })` will select
 inner WORD as subject of substitution.
 
+### `range.subject`
+
+Default : `nil`
+
+This allows you to control the subject (to be replaced) other than using
+motions. It accepts either a function, string, or a table with some special
+keys.
+
+If it is a string that will be used directly. If it is a function it will be
+called when the operator is used, and should return the subject to be replaced.
+If it is a table you may provide one of three keys with appropriate values:
+
+- `register = "a"` Use the contents of this register as the subject.
+- `expand = "<cword>"` Use the string given as the argument to `vim.fn.expand()` to get the subject.
+- `last_search = true` shortcut for `register = "/"` to use the last `/` search.
+
 #### `range.motion2`
 
 Default : `false`
@@ -274,6 +290,17 @@ around paragraph as range of substitution.
 You can combine `motion1` and `motion2` :
 `lua require('substitute.range').operator({ motion1='iw', motion2 = 'ap' })`
 will prepare substitution for inner word around paragraph.
+
+#### `range.range`
+
+Default : `nil`
+
+This allows you to control the range of the substitution other than using
+motions. This takes either a string directly, or a function returning string,
+this string is used as the range of the substitution command.
+
+For example, specifying `range = '%'` will make the substitution run over the
+whole file.
 
 #### `range.register`
 

--- a/README.md
+++ b/README.md
@@ -253,54 +253,58 @@ Default : `false`
 
 This will capture substituted text as you can use `\1` to quickly reuse it.
 
-#### `range.motion1`
-
-Default : `false`
-
-This will use this motion for the first motion of range substitution.
-
-eg. `lua require('substitute.range').operator({ motion1 = 'iW' })` will select
-inner WORD as subject of substitution.
-
 #### `range.subject`
 
 Default : `nil`
 
-This allows you to control the subject (to be replaced) other than using
-motions. It accepts either a function, string, or a table with some special
-keys.
+This allows you to control how the subject (to be replaced) is resolved. It
+accepts either a function, string, or a table with some special keys.
 
 If it is a string that will be used directly. If it is a function it will be
 called when the operator is used, and should return the subject to be replaced.
-If it is a table you may provide one of three keys with appropriate values:
+If it is a table you may provide one of the following keys with appropriate values:
 
 - `register = "a"` Use the contents of this register as the subject.
 - `expand = "<cword>"` Use the string given as the argument to `vim.fn.expand()` to get the subject.
-- `last_search = true` shortcut for `register = "/"` to use the last `/` search.
+- `last_search = true` Shortcut for `register = "/"` to use the last `/` search.
+- `motion = "iw"` Use this motion at the current cursor to get the subject
 
-#### `range.motion2`
-
-Default : `false`
-
-This will use this motion for the second motion of range substitution.
-
-eg. `lua require('substitute.range').operator({ motion2 = 'ap' })` will select
-around paragraph as range of substitution.
-
-You can combine `motion1` and `motion2` :
-`lua require('substitute.range').operator({ motion1='iw', motion2 = 'ap' })`
-will prepare substitution for inner word around paragraph.
+eg. `lua require('substitute.range').operator({ subject = {motion = 'iW'} })`
+will select inner WORD as subject of substitution.
 
 #### `range.range`
 
 Default : `nil`
 
-This allows you to control the range of the substitution other than using
-motions. This takes either a string directly, or a function returning string,
-this string is used as the range of the substitution command.
+This allows you to control the range of the substitution. This takes either a
+function, string, or a table with some special keys. If it is a string that
+will be used directly. If it is a function it will be called after the subject
+is resolved and should return a string. If it is a table you may provide one of
+the following keys with appropriate values:
 
-For example, specifying `range = '%'` will make the substitution run over the
-whole file.
+- `motion = "ap"` Use this motion from the current cursor to get the range.
+
+eg. specifying `range = '%'` will make the substitution run over the
+whole file. See `:h [range]` for all the possible values here.
+
+eg. `lua require('substitute.range').operator({ range = { motion = 'ap' } })`
+will select around paragraph as range of substitution.
+
+You can combine `subject` and `range` :
+`lua require('substitute.range').operator({ subject = { motion='iw' }, range = { motion = 'ap' } })`
+will prepare substitution for inner word around paragraph.
+
+#### `range.motion1` _DEPRECATED_
+
+Default : `false`
+
+This is option deprecated and equivalent to providing `subject.motion`.
+
+#### `range.motion2` _DEPRECATED_
+
+Default : `false`
+
+This option is deprecated and equivalent to `range.motion`
 
 #### `range.register`
 

--- a/lua/substitute/range.lua
+++ b/lua/substitute/range.lua
@@ -10,23 +10,20 @@ range.state = {
   overrides = {},
 }
 
-function range.operator(options)
-  range.state.overrides = config.get_range(options or {})
-  vim.o.operatorfunc = "v:lua.require'substitute.range'.operator_callback"
-  vim.api.nvim_feedkeys(string.format("g@%s", range.state.overrides.motion1 or ""), "mi", false)
-end
-
-function range.visual(options)
-  vim.cmd([[execute "normal! \<esc>"]])
-  range.state.overrides = config.get_range(options or {})
-  range.operator_callback(vim.fn.visualmode())
-end
-
-function range.word(options)
-  options = config.get_range(options or {})
-  options.motion1 = "iw"
-  options.complete_word = true
-  range.operator(options)
+local function get_text_from(text)
+  if type(text) == "function" then
+    return text()
+  elseif type(text) == "string" then
+    return text
+  elseif type(text) == "table" then
+    if text.register then
+      return vim.fn.getreg(text.register)
+    elseif text.expand then
+      return vim.fn.expand(text.expand)
+    elseif text.last_search then
+      return vim.fn.getreg("/")
+    end
+  end
 end
 
 local function get_escaped_subject(c)
@@ -48,6 +45,79 @@ local function create_match(c)
   })
 end
 
+function range.operator(options)
+  range.state.overrides = config.get_range(options or {})
+  if not range.state.overrides.motion1 and range.state.overrides.subject then
+    local text = get_text_from(range.state.overrides.subject)
+    if text then
+      range.state.subject = text
+      range.operator_callback()
+      return
+    else
+      pcall(function()
+        range.state.overrides.motion1 = range.state.overrides.subject.motion
+      end)
+    end
+  end
+
+  range.state.subject = nil
+  vim.o.operatorfunc = "v:lua.require'substitute.range'.operator_callback"
+  vim.api.nvim_feedkeys(string.format("g@%s", range.state.overrides.motion1 or ""), "mi", false)
+end
+
+local function get_selection_text(vmode)
+  local marks = utils.get_marks(0, vmode)
+  local text = utils.text(0, marks.start, marks.finish, vmode)
+  if vim.tbl_count(text) ~= 1 then
+    vim.notify("Multiline is not supported by SubstituteRange", vim.log.levels.INFO)
+    return
+  end
+
+  return table.remove(text)
+end
+
+local function get_selection_range(vmode)
+  local marks = utils.get_marks(0, vmode)
+  return string.format("%d,%d", marks.start.row, marks.finish.row)
+end
+
+function range.visual(options)
+  vim.cmd([[execute "normal! \<esc>"]])
+  range.state.overrides = config.get_range(options or {})
+  local vmode = vim.fn.visualmode()
+  range.state.subject = nil
+  range.operator_callback(vmode)
+end
+
+function range.in_selected_range(options)
+  options = config.get_range(options or {})
+  options.range = range.last_visual_range
+  range.operator(options)
+end
+function range.select_range(options)
+  vim.cmd([[execute "normal! \<esc>"]])
+  options = config.get_range(options or {})
+  range.last_visual_range = get_selection_range(vim.fn.visualmode())
+
+  if options.subject then
+    range.in_selected_range(options)
+  end
+end
+function range.visual_range(options)
+  if vim.api.nvim_get_mode().mode:lower() ~= "v" then
+    range.in_selected_range(options)
+  else
+    range.select_range(options)
+  end
+end
+
+function range.word(options)
+  options = config.get_range(options or {})
+  options.motion1 = "iw"
+  options.complete_word = true
+  range.operator(options)
+end
+
 function range.clear_match()
   if nil ~= range.state.match then
     vim.fn.matchdelete(range.state.match)
@@ -60,19 +130,27 @@ function range.clear_match()
 end
 
 function range.operator_callback(vmode)
-  local marks = utils.get_marks(0, vmode)
-  local text = utils.text(0, marks.start, marks.finish, vmode)
-  if vim.tbl_count(text) ~= 1 then
-    vim.notify("Multiline is not supported by SubstituteRange", vim.log.levels.INFO)
+  local c = config.get_range(range.state.overrides)
+
+  if range.state.subject == nil then
+    range.state.subject = get_selection_text(vmode)
+    if range.state.subject == nil then
+      return
+    end
+  end
+
+  if not c.motion2 and c.range then
+    if type(c.range) == "function" then
+      range.state.range = c.range()
+    elseif type(c.range) == "string" then
+      range.state.range = c.range
+    end
+    range.selection_operator_callback()
     return
   end
 
-  local c = config.get_range(range.state.overrides)
-
-  range.state.subject = table.remove(text)
-
   create_match(c)
-
+  range.state.range = "'[,']"
   vim.o.operatorfunc = "v:lua.require'substitute.range'.selection_operator_callback"
   vim.api.nvim_feedkeys(string.format("g@%s", c.motion2 or ""), "mi", false)
 end
@@ -93,21 +171,26 @@ function range.create_replace_command()
 
   local left = vim.api.nvim_replace_termcodes("<left>", true, false, true)
 
-  return string.format(
-    vim.api.nvim_replace_termcodes(":'[,']%s/%s/%s/g%s%s<Left><Left>%s", true, false, true),
+  vim.print(range)
+  local cmd = string.format(
+    -- vim.api.nvim_replace_termcodes(":%s%s/%s/%s/g%s%s%s", true, false, true),
+    ":%s%s/%s/%s/g%s%s%s",
+    range.state.range,
     c.prefix,
     get_escaped_subject(c),
     get_escaped_replacement(c),
     c.confirm and "c" or "",
     c.suffix,
-    string.rep(left, c.confirm and c.suffix:len() + 1 or c.suffix:len(), "")
+    string.rep(left, 2 + (c.confirm and c.suffix:len() + 1 or c.suffix:len()), "")
   )
+  vim.print(cmd)
+  return cmd
 end
 
 function range.selection_operator_callback()
   range.clear_match()
 
-  vim.api.nvim_feedkeys(range.create_replace_command(), "mi", true)
+  vim.api.nvim_feedkeys(range.create_replace_command(), "ni", true)
 end
 
 return range

--- a/lua/substitute/range.lua
+++ b/lua/substitute/range.lua
@@ -171,7 +171,6 @@ function range.create_replace_command()
 
   local left = vim.api.nvim_replace_termcodes("<left>", true, false, true)
 
-  vim.print(range)
   local cmd = string.format(
     -- vim.api.nvim_replace_termcodes(":%s%s/%s/%s/g%s%s%s", true, false, true),
     ":%s%s/%s/%s/g%s%s%s",
@@ -183,7 +182,7 @@ function range.create_replace_command()
     c.suffix,
     string.rep(left, 2 + (c.confirm and c.suffix:len() + 1 or c.suffix:len()), "")
   )
-  vim.print(cmd)
+
   return cmd
 end
 


### PR DESCRIPTION
For the former the main use cases is using vim.fn.getreg or vim.fn.expand so we allow shorthands for that

For the latter the main use case is directly specifying "%" for everywhere. But it can also be used for using the visual range
