### PR TITLE
fix: `substitute.range.word`

### DIFF
--- a/lua/substitute/range.lua
+++ b/lua/substitute/range.lua
@@ -117,7 +117,7 @@ end
 
 function range.word(options)
   options = config.get_range(options or {})
-  options.subject.motion = "iw"
+  options.subject = { expand = "<cword>" }
   options.complete_word = true
   range.operator(options)
 end


### PR DESCRIPTION
`E5108: Error executing lua: substitute.nvim/lua/substitute/range.lua:120: attempt to index field 'subject' (a nil value)`
