### PR TITLE
fix(exchange): fix highlight range for linewise exchange

### DIFF
--- a/lua/substitute/exchange.lua
+++ b/lua/substitute/exchange.lua
@@ -14,7 +14,7 @@ local prepare_exchange = function(vmode)
     hl_namespace,
     "SubstituteExchange",
     { marks.start.row - 1, regtype ~= "l" and marks.start.col or 0 },
-    { marks.finish.row - 1, regtype ~= "l" and marks.finish.col + 1 or -1 },
+    { marks.finish.row - 1, regtype ~= "l" and marks.finish.col + 1 or 0 },
     { regtype = ({ char = "v", line = "V" })[vmode], inclusive = false }
   )
 


### PR DESCRIPTION
In linewise mode, and there is only one line selected, exchange line doesn't highlighted.