### PR TITLE
refactor: replace deprecated vim.highlight with vim.hl

### DIFF
--- a/lua/substitute.lua
+++ b/lua/substitute.lua
@@ -120,7 +120,7 @@ function substitute.highlight_substituted_text(marks)
   vim.api.nvim_buf_clear_namespace(0, substitute.hl_substitute, 0, -1)
 
   for _, mark in pairs(marks) do
-    vim.highlight.range(
+    vim.hl.range(
       0,
       substitute.hl_substitute,
       "SubstituteSubstituted",

--- a/lua/substitute/exchange.lua
+++ b/lua/substitute/exchange.lua
@@ -9,7 +9,7 @@ local prepare_exchange = function(vmode)
   local marks = utils.get_marks(0, vmode)
   local regtype = utils.get_register_type(vmode)
 
-  vim.highlight.range(
+  vim.hl.range(
     0,
     hl_namespace,
     "SubstituteExchange",


### PR DESCRIPTION
As of Neovim 0.11, `vim.highlight` has been renamed to `vim.hl` (see [here](https://neovim.io/doc/user/deprecated.html#vim.highlight)). 

This produces a warning in `:checkhealth` as follows:
<img width="910" height="240" alt="Screenshot 2026-02-17 at 5 48 12 PM" src="https://github.com/user-attachments/assets/34928474-711b-44c5-a1f9-5841a8d93a15" />

The fix only requires a simple renaming.
